### PR TITLE
支持JDK8编译

### DIFF
--- a/src/main/java/com/kepler/management/transfer/impl/DefaultTransfers.java
+++ b/src/main/java/com/kepler/management/transfer/impl/DefaultTransfers.java
@@ -84,7 +84,7 @@ public class DefaultTransfers implements Transfers {
 	}
 
 	private void remove(Transfer each) {
-		Transfer removed = Transfer.class.cast(this.transfers.remove(each.local(), each.target()));
+		Transfer removed = Transfer.class.cast(this.transfers.removeMultiKey(each.local(), each.target()));
 		if (removed != null) {
 			DefaultTransfers.LOGGER.warn("Transfer: (" + removed.local() + ") to (" + removed.target() + ") removed ... (" + this + ")");
 		}

--- a/src/main/java/com/kepler/org/apache/commons/collections/map/MultiKeyMap.java
+++ b/src/main/java/com/kepler/org/apache/commons/collections/map/MultiKeyMap.java
@@ -197,7 +197,7 @@ public class MultiKeyMap
      * @param key2  the second key
      * @return the value mapped to the removed key, null if key not in map
      */
-    public Object remove(Object key1, Object key2) {
+    public Object removeMultiKey(Object key1, Object key2) {
         int hashCode = hash(key1, key2);
         int index = map.hashIndex(hashCode, map.data.length);
         AbstractHashedMap.HashEntry entry = map.data[index];
@@ -327,7 +327,7 @@ public class MultiKeyMap
      * @param key3  the third key
      * @return the value mapped to the removed key, null if key not in map
      */
-    public Object remove(Object key1, Object key2, Object key3) {
+    public Object removeMultiKey(Object key1, Object key2, Object key3) {
         int hashCode = hash(key1, key2, key3);
         int index = map.hashIndex(hashCode, map.data.length);
         AbstractHashedMap.HashEntry entry = map.data[index];
@@ -467,7 +467,7 @@ public class MultiKeyMap
      * @param key4  the fourth key
      * @return the value mapped to the removed key, null if key not in map
      */
-    public Object remove(Object key1, Object key2, Object key3, Object key4) {
+    public Object removeMultiKey(Object key1, Object key2, Object key3, Object key4) {
         int hashCode = hash(key1, key2, key3, key4);
         int index = map.hashIndex(hashCode, map.data.length);
         AbstractHashedMap.HashEntry entry = map.data[index];
@@ -617,7 +617,7 @@ public class MultiKeyMap
      * @param key5  the fifth key
      * @return the value mapped to the removed key, null if key not in map
      */
-    public Object remove(Object key1, Object key2, Object key3, Object key4, Object key5) {
+    public Object removeMultiKey(Object key1, Object key2, Object key3, Object key4, Object key5) {
         int hashCode = hash(key1, key2, key3, key4, key5);
         int index = map.hashIndex(hashCode, map.data.length);
         AbstractHashedMap.HashEntry entry = map.data[index];

--- a/src/main/java/com/kepler/service/imported/ImportedServiceFactory.java
+++ b/src/main/java/com/kepler/service/imported/ImportedServiceFactory.java
@@ -2,7 +2,8 @@ package com.kepler.service.imported;
 
 import java.lang.reflect.Method;
 import java.util.Arrays;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.Future;
 
 import net.sf.cglib.proxy.Enhancer;
@@ -43,7 +44,7 @@ public class ImportedServiceFactory<T> implements FactoryBean<T> {
 
 	private final IDGenerator generator;
 
-	private final List<Method> methods;
+	private final Set<Method> methods;
 
 	private final Imported imported;
 
@@ -89,7 +90,7 @@ public class ImportedServiceFactory<T> implements FactoryBean<T> {
 		this.generator = generator;
 		this.processor = processor;
 		this.validation = validation;
-		this.methods = Arrays.asList(clazz.getMethods());
+		this.methods = new HashSet<>(Arrays.asList(clazz.getMethods()));
 		this.service = new Service(clazz, version, catalog);
 		this.profile = profiles.add(this.service, profile);
 	}


### PR DESCRIPTION
1.接口方法由List改用Set存放, 稳定contains判断的消耗.

2.修改方法名, 解决JDK8新增的默认方法(Map.remove(arg1, arg2))导致Commons  Collections中的MultiKeyMap编译失败.
