### PR TITLE
在Spring启动失败时, ZkContext.destory方法NPE, 不过不影响使用.

### DIFF
--- a/src/main/java/com/kepler/zookeeper/ZkContext.java
+++ b/src/main/java/com/kepler/zookeeper/ZkContext.java
@@ -400,16 +400,20 @@ public class ZkContext implements Demotion, Imported, Exported, ConfigSync, Appl
 		 * 注销Status节点
 		 */
 		public void destroy4status() {
-			this.destroy(this.status);
-			this.status = null;
+			if(status != null){
+				this.destroy(this.status);
+				this.status = null;
+			}
 		}
 
 		/**
 		 * 注销Config节点
 		 */
 		public void destroy4config() {
-			this.destroy(this.config);
-			this.config = null;
+			if(config != null){
+				this.destroy(this.config);
+				this.config = null;
+			}
 		}
 
 		/**


### PR DESCRIPTION
在Spring启动但是因为其他bean初始化的原因而启动失败时, Spring会调用destory方法, 而这个时候ZkContext还没有收到ContextRefreshedEvent, 进而没有初始化status和config, 所以destory方法报空指针, 不过不影响使用.
