### PR TITLE
增加配置项com.kepler.connection.impl.defaultconnect.establish_quiet

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.kepler</groupId>
 	<artifactId>kepler-all</artifactId>
-	<version>0.0.14</version>
+	<version>0.0.15</version>
 	<packaging>jar</packaging>
 	<name>kepler</name>
 	<url>http://maven.apache.org</url>


### PR DESCRIPTION
默认为false，为true时与服务端连接无法建立时不再打印异常栈